### PR TITLE
Add an idle timer to clear presence after a certain inactivity period

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ OBJS := $(SRC:$(SRC_DIR)/%.cpp=$(OBJ_DIR)/%.o)
 
 CXX = g++
 CPPFLAGS := $(shell python3-config --cflags) -Iinclude -MMD -MP
-CXXFLAGS := -Wall -fPIE
+CXXFLAGS := -std=c++17 -Wall -fPIE
 LDLIBS := -lpthread -ldiscord-rpc
 LDFLAGS := -Llib $(shell python3-config --ldflags --embed)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Anyway, hope you don't dislike my terrible code, and that all that should be cre
 
 The `build.sh` file included should do all the work for you. It's nothing really fancy, but it should work.
 
-First it checks (or at least it should) if you have installed the right dependencies. You'll need `g++`, `cmake` and `python3`. As far as I know, it should work with any version of `python3`, but I've tested it working with 
+First it checks (or at least it should) if you have installed the right dependencies. You'll need `g++`, `cmake` and `python3`. `g++` has to support the C++17 standard (tested in g++ version 10.2.1 and 14.1.1) and, as far as I know, it should work with any version of `python3`, but I've tested it working with Python 3.9.2 and 3.12.3.
 
 Also, about python, you'll need the unofficial YouTube Music API module by [sigma67](https://github.com/sigma67/). If you skipped the introduction, [here's the repo again](https://github.com/sigma67/ytmusicapi) and you can follow [here](https://ytmusicapi.readthedocs.io/en/latest/setup.html) instructions in how to install it.
 

--- a/src/idle_timer.cpp
+++ b/src/idle_timer.cpp
@@ -1,0 +1,34 @@
+#include "idle_timer.h"
+
+const std::chrono::minutes IdleTimer::IDLE_PERIOD = std::chrono::minutes(15);
+
+IdleTimer::IdleTimer(std::function<void()> idleTask) {
+    task = idleTask;
+    stopSignal = false;
+}
+
+void IdleTimer::start() {
+    cancel();
+    currentThread = std::thread([this]() {
+        std::unique_lock<std::mutex> lock(timerMutex);
+        bool stoppedEarly = timer.wait_for(lock, IDLE_PERIOD, [this]{ return stopSignal == true; });
+        if (!stoppedEarly)
+            task();
+    });
+}
+
+void IdleTimer::cancel() {
+    {
+        std::lock_guard<std::mutex> lock(timerMutex);
+        stopSignal = true;
+        timer.notify_all();
+    }
+    if (currentThread.joinable())
+        currentThread.join();
+    {
+        std::lock_guard<std::mutex> lock(timerMutex);
+        stopSignal = false;
+    }
+}
+
+IdleTimer::~IdleTimer() { cancel(); }

--- a/src/idle_timer.h
+++ b/src/idle_timer.h
@@ -1,0 +1,49 @@
+#ifndef __IDLE_TIMER_H__
+#define __IDLE_TIMER_H__
+
+#include <chrono>
+#include <functional>
+#include <mutex>
+#include <condition_variable>
+#include <atomic>
+#include <thread>
+
+class IdleTimer {
+    public: 
+        /**
+         * Default constructor.
+         * Takes an `idleTask` that should be run when the timer expires.
+         */
+        IdleTimer(std::function<void()> idleTask);
+
+        /**
+         * Starts the idle timer that will run the task function on timeout after `IDLE_PERIOD` 
+         * elapsed.
+         */
+        void start();
+
+        /**
+         * Stops the idle timer if it's running.
+         * The task function WON'T be run.
+         */
+        void cancel();
+        
+        /**
+         * Default destructor.
+         */
+        ~IdleTimer();
+
+    private:
+        /**
+         * Idle period: Period that has to elapse for the task provided to be run.
+         */
+        static const std::chrono::minutes IDLE_PERIOD;
+
+        std::function<void()> task;
+        std::condition_variable timer;
+        std::mutex timerMutex;
+        std::atomic<bool> stopSignal;
+        std::thread currentThread;
+};
+
+#endif /* __IDLE_TIMER_H__ */

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -115,7 +115,6 @@ int parseRequest (char* request, PyObject *ytmusic) {
             cacheMap.insert(toSend.track, mapEntry);
     }
 
-    // TODO: show image url in print
     toSend.print(); // show update received
     
     // all good if I got to here

--- a/src/parse.h
+++ b/src/parse.h
@@ -31,7 +31,7 @@ static const char* BASE_URL = "https://music.youtube.com/watch?v=";
  * and return a PyObject with the song metadata.
  * If the song isn't found, returns a NULL pointer.
  */
-PyObject* getMetadataHistory (std::string track_name, PyObject *ytmusic); // TODO: check if description is OK.
+PyObject* getMetadataHistory (std::string track_name, PyObject *ytmusic);
 
 /*
  * Parses the JSON received in a request, checks for validity, and builds an

--- a/src/presence.h
+++ b/src/presence.h
@@ -18,6 +18,11 @@ static const char *LISTEN_ALONG_TXT = "Listen Along";
 void discordInit();
 
 /*
+ * Clear Discord Rich Presence.
+ */
+void clearPresence();
+
+/*
  * Update Discord Rich Presence with specified update information included in `u`.
  */
 void updateDiscordPresence (upd_struct &u);


### PR DESCRIPTION
Noticed during use that if I dismissed the YT Music app outside my local network, the discord may be stuck in a playing state for long periods of time without me noticing.

Therefore, I'm adding an idle timer to clear the presence after no events were received for some period of time, default set to 15 minutes.